### PR TITLE
Fix: select 및 textarea 관련 경고 해결

### DIFF
--- a/src/components/ProductReview/Review.js
+++ b/src/components/ProductReview/Review.js
@@ -1,16 +1,33 @@
-import React from 'react';
+import React, { useState } from 'react';
 import css from './Review.module.scss';
+import ReviewModal from '../ReviewModal/ReviewModal';
 
 function Review() {
+  const [modalOpen, setModalOpen] = useState(false);
+  const openModal = () => {
+    setModalOpen(true);
+  };
+  const closeModal = () => {
+    setModalOpen(false);
+  };
+
   return (
     <div className={css.container}>
+      <ReviewModal
+        close={closeModal}
+        open={modalOpen}
+        header="상품후기 수정하기"
+      />
       <div className={css.review_info}>
         <div className={css.rate}>★★★★★</div>
         <div className={css.date}>2022.05.31</div>
         <div className={css.username}>김코드</div>
       </div>
       <span className={css.text}>텍스트</span>
-      <button>삭제</button>
+      <div className={css.buttons}>
+        <button onClick={openModal}>수정</button>
+        <button>삭제</button>
+      </div>
     </div>
   );
 }

--- a/src/components/ProductReview/Review.js
+++ b/src/components/ProductReview/Review.js
@@ -17,6 +17,7 @@ function Review() {
         close={closeModal}
         open={modalOpen}
         content="test"
+        stars="1"
         header="상품후기 수정하기"
       />
       <div className={css.review_info}>

--- a/src/components/ProductReview/Review.js
+++ b/src/components/ProductReview/Review.js
@@ -16,6 +16,7 @@ function Review() {
       <ReviewModal
         close={closeModal}
         open={modalOpen}
+        content="test"
         header="상품후기 수정하기"
       />
       <div className={css.review_info}>

--- a/src/components/ProductReview/Review.module.scss
+++ b/src/components/ProductReview/Review.module.scss
@@ -27,15 +27,18 @@
     word-break: break-all;
     line-height: 24px;
   }
-  button {
-    position: absolute;
-    width: 60px;
-    height: 26px;
-    right: 20px;
-    bottom: 20px;
-    background: #c7c7c7;
-    color: white;
-    border: 0;
-    cursor: pointer;
+  .buttons {
+    display: flex;
+    button {
+      width: 50px;
+      height: 26px;
+      position: relative;
+      top: 40px;
+      margin: 4px;
+      background: #c7c7c7;
+      color: white;
+      border: 0;
+      cursor: pointer;
+    }
   }
 }

--- a/src/components/ReviewModal/ReviewModal.js
+++ b/src/components/ReviewModal/ReviewModal.js
@@ -1,13 +1,24 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import css from './ReviewModal.module.scss';
 
 const ReviewModal = props => {
-  const { open, close, header, content } = props;
+  const { open, close, header, content, stars } = props;
   useEffect(() => {
     open
       ? (document.body.style.overflow = 'hidden')
       : (document.body.style.overflow = 'unset');
   }, [open]);
+
+  const [text, setText] = useState(content);
+  const handleTextarea = e => {
+    setText(e.target.value);
+  };
+
+  const [select, setSelect] = useState(stars);
+  const handleSelect = e => {
+    setSelect(e.target.value);
+  };
+
   return (
     <div className={open ? `${css.openModal} ${css.modal}` : css.modal}>
       {open ? (
@@ -19,15 +30,15 @@ const ReviewModal = props => {
             </button>
           </header>
           <main className={css.textarea}>
-            <select>
-              <option>★★★★★</option>
-              <option>★★★★</option>
-              <option>★★★</option>
-              <option>★★</option>
-              <option>★</option>
+            <select value={select} onChange={handleSelect}>
+              <option value="5">★★★★★</option>
+              <option value="4">★★★★</option>
+              <option value="3">★★★</option>
+              <option value="2">★★</option>
+              <option value="1">★</option>
             </select>
             <div className={css.textarea_header} />
-            <textarea>{content}</textarea>
+            <textarea value={text} onChange={handleTextarea} />
           </main>
           <footer>
             <button>리뷰등록</button>

--- a/src/components/ReviewModal/ReviewModal.js
+++ b/src/components/ReviewModal/ReviewModal.js
@@ -1,7 +1,12 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import css from './ReviewModal.module.scss';
 
 const ReviewModal = props => {
+  useEffect(() => {
+    open
+      ? (document.body.style.overflow = 'hidden')
+      : (document.body.style.overflow = 'unset');
+  });
   const { open, close, header, content } = props;
   return (
     <div className={open ? `${css.openModal} ${css.modal}` : css.modal}>

--- a/src/components/ReviewModal/ReviewModal.js
+++ b/src/components/ReviewModal/ReviewModal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import css from './ReviewModal.module.scss';
 
 const ReviewModal = props => {
-  const { open, close, header } = props;
+  const { open, close, header, content } = props;
   return (
     <div className={open ? `${css.openModal} ${css.modal}` : css.modal}>
       {open ? (
@@ -22,7 +22,7 @@ const ReviewModal = props => {
               <option>★</option>
             </select>
             <div className={css.textarea_header} />
-            <textarea>{props.children}</textarea>
+            <textarea>{content}</textarea>
           </main>
           <footer>
             <button>리뷰등록</button>

--- a/src/components/ReviewModal/ReviewModal.js
+++ b/src/components/ReviewModal/ReviewModal.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import css from './ReviewModal.module.scss';
+
+const ReviewModal = props => {
+  const { open, close, header } = props;
+  return (
+    <div className={open ? `${css.openModal} ${css.modal}` : css.modal}>
+      {open ? (
+        <section>
+          <header>
+            {header}
+            <button className={css.close} onClick={close}>
+              &times;
+            </button>
+          </header>
+          <main className={css.textarea}>
+            <select>
+              <option>★★★★★</option>
+              <option>★★★★</option>
+              <option>★★★</option>
+              <option>★★</option>
+              <option>★</option>
+            </select>
+            <div className={css.textarea_header} />
+            <textarea>{props.children}</textarea>
+          </main>
+          <footer>
+            <button>리뷰등록</button>
+          </footer>
+        </section>
+      ) : null}
+    </div>
+  );
+};
+
+export default ReviewModal;

--- a/src/components/ReviewModal/ReviewModal.js
+++ b/src/components/ReviewModal/ReviewModal.js
@@ -2,12 +2,12 @@ import React, { useEffect } from 'react';
 import css from './ReviewModal.module.scss';
 
 const ReviewModal = props => {
+  const { open, close, header, content } = props;
   useEffect(() => {
     open
       ? (document.body.style.overflow = 'hidden')
       : (document.body.style.overflow = 'unset');
-  });
-  const { open, close, header, content } = props;
+  }, [open]);
   return (
     <div className={open ? `${css.openModal} ${css.modal}` : css.modal}>
       {open ? (

--- a/src/components/ReviewModal/ReviewModal.module.scss
+++ b/src/components/ReviewModal/ReviewModal.module.scss
@@ -1,0 +1,118 @@
+.modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 99;
+  background-color: rgba(0, 0, 0, 0.6);
+  button {
+    outline: none;
+    cursor: pointer;
+    border: 0;
+  }
+  section {
+    width: 860px;
+    height: 462px;
+    margin: 0 auto;
+    border-radius: 0.3rem;
+    background-color: #fff;
+    overflow: hidden;
+    header {
+      position: relative;
+      padding: 16px 0 16px 0px;
+      margin: 0 30px;
+      border-bottom: 2px solid gray;
+      font-weight: 700;
+      button {
+        position: absolute;
+        bottom: -12px;
+        right: 8px;
+        width: 30px;
+        font-size: 55px;
+        text-align: center;
+        color: #999;
+        background-color: transparent;
+      }
+    }
+    main {
+      padding: 16px;
+      margin: 20px 0;
+      width: 300px;
+      height: 300px;
+      select {
+        width: 796.5px;
+        border: 1px solid #e8e8e8;
+        color: #ffcc00;
+        font-size: 15px;
+        outline: none;
+        height: 30px;
+        margin: 0 0 0 15px;
+      }
+      .textarea_header {
+        position: relative;
+        top: 16px;
+        left: 1px;
+        width: 795px;
+        height: 30px;
+        border: 1px solid #e8e8e8;
+        border-bottom: 0;
+        background-color: #f8f8f8;
+        margin: 0 0 0 15px;
+      }
+      textarea {
+        margin: 16px;
+        width: 795px;
+        height: 200px;
+        border: 1px solid #e8e8e8;
+        outline: none;
+        resize: none;
+      }
+    }
+    footer {
+      text-align: right;
+      width: 795px;
+      height: 60px;
+      border: 1px solid #e8e8e8;
+      border-top: 0;
+      position: relative;
+      bottom: 30px;
+      left: 32px;
+      button {
+        height: 97%;
+        width: 100px;
+        position: relative;
+        top: 2px;
+        padding: 6px 12px;
+        color: #fff;
+        background-color: #666666;
+        font-size: 13px;
+      }
+    }
+  }
+}
+
+.openModal {
+  display: flex;
+  align-items: center;
+  animation: modal-bg-show 0.3s;
+}
+@keyframes modal-show {
+  from {
+    opacity: 0;
+    margin-top: -50px;
+  }
+  to {
+    opacity: 1;
+    margin-top: 0;
+  }
+}
+@keyframes modal-bg-show {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/src/pages/ProductDetail/ProductDetail.js
+++ b/src/pages/ProductDetail/ProductDetail.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Image from '../../elements/Image';
 import ProductInfo from '../../components/ProductInfo/ProductInfo';
 import ProductDetailInfo from '../../components/ProductDetailInfo/ProductDetailInfo';


### PR DESCRIPTION
## :: 최근 작업 주제

- [X] 레이아웃 구현
- [ ] 기능 추가
- [ ] 리뷰 반영
- [X] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 리뷰 수정 모달 UI 구현
- 모달 외부 영역 비활성화 기능 구현

<br />

## :: 구현 사항 설명
<br/>
1. 리뷰 수정 모달 UI 구현

- 리뷰 수정 버튼을 눌렀을 때 나타나고, 닫기 버튼을 눌렀을 때 사라지는
리뷰 수정 모달의 UI를 구현했습니다.

<br/>
2. 구조 분해 할당 관련 경고 해결

- ReviewModal 컴포넌트에서 사용하지 않는 props를 삭제했습니다.

<br/>
3.. 리뷰 수정 모달 외부 영역 비활성화 기능 구현

- ReviewModal 컴포넌트에서 useEffect 훅과 overflow 속성을 활용해
리뷰 수정 모달 외부 영역을 비활성화했습니다.
- (리팩토링) 의존성 배열을 추가하여 open 값이 변경될 때만 useEffect 
내부 함수가 동작하도록 했습니다.
```
  useEffect(() => {
    open
      ? (document.body.style.overflow = 'hidden')
      : (document.body.style.overflow = 'unset');
  },[open]);
```

<br/>
4. select 및 textarea 관련 경고 해결

- select 태그에서 selected 속성을 사용하지 말라는 경고가 발생했고,
textarea 태그에서 children을 설정하지 말라는 경고가 발생했습니다.
useState 훅과 onChange 이벤트를 활용해 값을 동적으로 할당함으로써
문제를 해결했습니다.

<br />

## :: 성장 포인트

- 구조 분해 할당 관련 경고가 발생했고, ReviewModal에서 사용하지 않는 props를 
삭제함으로써 문제를 해결했습니다.
- css의 unset 키워드에 대해 새롭게 알게 되었습니다.

<br />

## :: 기타 질문 및 특이 사항

- 없음
