### PR TITLE
Fix : nav drop 메뉴 보이지 않은 문제 수정

### DIFF
--- a/src/components/Nav/Nav.module.scss
+++ b/src/components/Nav/Nav.module.scss
@@ -62,8 +62,10 @@
 
 /* drop nav */
 .prd_category {
+  position: relative;
   width: 100%;
   background-color: #333;
+  z-index: 1;
   &_all {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## :: 최근 작업 주제

- [ ] 레이아웃 구현
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- nav 컴포넌트 수정

<br />

## :: 구현 사항 설명

1. nav 컴포넌트에서 drop 메뉴가 보이지 않은 문제 수정

- 일부 페이지에서 drop 메뉴가 보이지 않은 문제 발생
- drop 메뉴의 position을 변경해 주고 z-index = 1을 주어 수정

<br />

## :: 성장 포인트

- position이 static이 아닐 경우에만 z-index가 적용되는 것을 알게 되었습니다

<br />

## :: 기타 질문 및 특이 사항

- 없음
