### PR TITLE
Add: 페이지 내 특정 위치로 이동 기능 추가

### DIFF
--- a/src/components/ProductTab/ProductTab.js
+++ b/src/components/ProductTab/ProductTab.js
@@ -1,13 +1,19 @@
 import React from 'react';
 import css from './ProductTab.module.scss';
-import { Link } from 'react-router-dom';
 
 function ProductTab() {
+  const screenHeight = document.body.scrollHeight;
+
+  const moveToTab = height => {
+    window.scrollTo(0, height);
+  };
   return (
     <section className={css.tab}>
-      <Link to>상품상세정보</Link>
-      <Link to>상품후기</Link>
-      <Link to>배송/교환 및 반품안내</Link>
+      <button onClick={() => moveToTab(800)}>상품상세정보</button>
+      <button onClick={() => moveToTab(3600)}>상품후기</button>
+      <button onClick={() => moveToTab(screenHeight)}>
+        배송/교환 및 반품안내
+      </button>
     </section>
   );
 }

--- a/src/components/ProductTab/ProductTab.module.scss
+++ b/src/components/ProductTab/ProductTab.module.scss
@@ -4,7 +4,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  a {
+  button {
     display: inline-block;
     font-size: 14px;
     background-color: white;


### PR DESCRIPTION
## :: 최근 작업 주제

- [ ] 레이아웃 구현
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 페이지 내 특정 위치로 이동 기능 구현

<br />

## :: 구현 사항 설명
<br>
1. 페이지 내 특정 위치로 이동 기능 추가

- window 객체의 scrollTo 메서드를 사용하여 상품 상세 페이지 내에서 
ProductTab 내부의 버튼을 누를 때마다 적절한 위치로 스크롤하게 했습니다.

<br />

## :: 성장 포인트

- 배송/교환 및 반품안내 버튼을 누를 때 맨 밑으로 이동시켜야 했는데 
고정된 값을 사용한 경우 추가되는 댓글의 높이로 인해 원하는 대로 동작하지 않았습니다.
document.body.scrollHeight를 사용해 브라우저의 전체 높이를 구하고
브라우저의 전체 높이만큼 스크롤하는 기능을 추가함으로써 문제를 해결했습니다.

<br />

## :: 기타 질문 및 특이 사항

- 없음
