### PR TITLE
Add: 장바구니 수정,  삭제 기능 추가

### DIFF
--- a/src/components/CartProduct/CartProduct.js
+++ b/src/components/CartProduct/CartProduct.js
@@ -46,7 +46,7 @@ function CartProduct(props) {
     window.location.reload();
   };
 
-  const countDown = () => {
+  const countDown = async () => {
     if (count > 1) {
       setCount(count - 1);
       const cart = JSON.parse(localStorage.getItem('cart')) || [];
@@ -68,7 +68,16 @@ function CartProduct(props) {
           })
         )
       );
+      window.location.reload();
     }
+  };
+
+  const deleteProduct = () => {
+    const cart = JSON.parse(localStorage.getItem('cart')) || [];
+    localStorage.setItem(
+      'cart',
+      JSON.stringify(cart.filter(item => item.id !== id))
+    );
     window.location.reload();
   };
 
@@ -81,6 +90,7 @@ function CartProduct(props) {
   return (
     <tr className={css.container}>
       <td className={css.info}>
+        <button onClick={deleteProduct}>삭제</button>
         {image && <Image className={css.img} size={70} src={image} />}
         <div className={css.product_name}>
           <div>{name}</div>

--- a/src/components/CartProduct/CartProduct.js
+++ b/src/components/CartProduct/CartProduct.js
@@ -19,8 +19,58 @@ function CartProduct(props) {
 
   const name = productInfo?.name;
   const subCategory = productInfo?.sub_category;
-  const count = cart.count;
   const price = productInfo.price;
+
+  const [count, setCount] = useState(cart.count);
+  const countUp = () => {
+    setCount(count + 1);
+    const cart = JSON.parse(localStorage.getItem('cart')) || [];
+    localStorage.setItem(
+      'cart',
+      JSON.stringify(
+        cart.map(obj => {
+          if (obj.id === id) {
+            return {
+              ...obj,
+              count: obj.count + 1,
+              totalPrice: obj.totalPrice + price,
+            };
+          } else {
+            return {
+              ...obj,
+            };
+          }
+        })
+      )
+    );
+    window.location.reload();
+  };
+
+  const countDown = () => {
+    if (count > 1) {
+      setCount(count - 1);
+      const cart = JSON.parse(localStorage.getItem('cart')) || [];
+      localStorage.setItem(
+        'cart',
+        JSON.stringify(
+          cart.map(obj => {
+            if (obj.id === id) {
+              return {
+                ...obj,
+                count: obj.count - 1,
+                totalPrice: obj.totalPrice - price,
+              };
+            } else {
+              return {
+                ...obj,
+              };
+            }
+          })
+        )
+      );
+    }
+    window.location.reload();
+  };
 
   const imageList = productInfo?.productImages;
   const [image, setImage] = useState(null);
@@ -37,7 +87,13 @@ function CartProduct(props) {
           <div className={css.sub_category}>{subCategory}</div>
         </div>
       </td>
-      <td className={css.count}>{count}</td>
+      <td className={css.count}>
+        <div className={css.buy_input}>
+          <button onClick={countDown}>-</button>
+          <input disabled type="number" value={count} />
+          <button onClick={countUp}>+</button>
+        </div>
+      </td>
       <td className={css.price}>₩ {price}</td>
       <td className={css.total_price}>₩ {count * price}</td>
       {firstProduct && (

--- a/src/components/CartProduct/CartProduct.module.scss
+++ b/src/components/CartProduct/CartProduct.module.scss
@@ -11,6 +11,15 @@
     text-align: center;
     display: flex;
     align-items: center;
+    button {
+      width: 50px;
+      background-color: transparent;
+      border: 0;
+      color: red;
+      cursor: pointer;
+      padding: 0;
+      margin: 0;
+    }
     .img {
       position: relative;
       left: 100px;
@@ -29,7 +38,6 @@
   }
   .count {
     position: relative;
-    bottom: 30px;
     width: 185px;
 
     .buy_input {
@@ -54,19 +62,19 @@
   }
   .price {
     position: relative;
-    bottom: 30px;
+    bottom: 5px;
     width: 160px;
     min-width: 160px;
   }
   .total_price {
     position: relative;
-    bottom: 30px;
+    bottom: 5px;
     width: 160px;
     min-width: 160px;
   }
   .ship {
     position: relative;
-    bottom: 30px;
+    bottom: 10px;
     font-size: 14px;
     color: #acacac;
     line-height: 20px;

--- a/src/components/CartProduct/CartProduct.module.scss
+++ b/src/components/CartProduct/CartProduct.module.scss
@@ -31,6 +31,26 @@
     position: relative;
     bottom: 30px;
     width: 185px;
+
+    .buy_input {
+      display: flex;
+      border: 1px solid gray;
+      padding: 4px;
+      position: relative;
+      bottom: 6px;
+      input {
+        width: 53px;
+        border: none;
+        outline: none;
+        background-color: transparent;
+        text-align: center;
+      }
+    }
+    button {
+      border: 0;
+      cursor: pointer;
+      background-color: transparent;
+    }
   }
   .price {
     position: relative;

--- a/src/components/CartProduct/CartProduct.module.scss
+++ b/src/components/CartProduct/CartProduct.module.scss
@@ -47,6 +47,8 @@
       position: relative;
       bottom: 6px;
       input {
+        position: relative;
+        left: 6px;
         width: 53px;
         border: none;
         outline: none;

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -22,6 +22,8 @@ function Cart() {
     }
   }, [isUpdated]);
 
+  const isExist = totalCount === 0 || totalCount === undefined;
+
   const delCart = () => {
     localStorage.removeItem('cart');
     setIsUpdated(true);
@@ -56,22 +58,26 @@ function Cart() {
                 return (
                   <CartProduct key={idx} firstProduct={true} cart={cart} />
                 );
-              else return <CartProduct key={idx} cart={cart} />;
+              else
+                return (
+                  <CartProduct
+                    key={idx}
+                    cart={cart}
+                    setIsUpdated={setIsUpdated}
+                    isUpdated={isUpdated}
+                  />
+                );
             })}
         </tbody>
       </table>
       <div className={css.order_price}>
         <span>총 {totalCount}개의 금액</span>{' '}
-        <span className={css.price}>
-          ₩ {totalCount !== undefined ? totalPrice : 0}
-        </span>{' '}
-        + <span>배송비</span>{' '}
-        <span className={css.price}>
-          ₩ {totalCount !== undefined ? 2500 : 0}
-        </span>{' '}
-        = <span className={css.price}>총 주문금액</span>{' '}
+        <span className={css.price}>₩ {isExist ? 0 : totalPrice}</span> +{' '}
+        <span>배송비</span>{' '}
+        <span className={css.price}>₩ {isExist ? 0 : 2500}</span> ={' '}
+        <span className={css.price}>총 주문금액</span>{' '}
         <span className={css.total_price}>
-          ₩ {totalCount !== undefined ? totalPrice + 2500 : 0}
+          ₩ {isExist ? 0 : totalPrice + 2500}
         </span>
       </div>
       <button onClick={delCart} className={css.delete_btn}>

--- a/src/pages/Cart/Cart.module.scss
+++ b/src/pages/Cart/Cart.module.scss
@@ -50,7 +50,7 @@
     }
   }
   .order_price {
-    min-width: 750px;
+    min-width: 1100px;
     background-color: rgb(224, 224, 224);
     font-size: 18px;
     text-align: center;

--- a/src/pages/Cart/Cart.module.scss
+++ b/src/pages/Cart/Cart.module.scss
@@ -1,6 +1,6 @@
 .container {
-  width: 1000px;
-  margin: auto;
+  width: 1100px;
+  margin: 0 auto;
 
   h2 {
     font-size: 42px;
@@ -11,7 +11,8 @@
   }
 
   table {
-    min-width: 700px;
+    width: 1100px;
+    margin: auto;
     caption {
       font-size: 22px;
       height: 30px;
@@ -19,7 +20,6 @@
       position: relative;
       text-align: left;
     }
-    margin: 0 auto;
     th {
       color: #8f8f8f;
       border-top: 1px solid black;
@@ -50,12 +50,12 @@
     }
   }
   .order_price {
-    min-width: 1100px;
+    width: 1100px;
     background-color: rgb(224, 224, 224);
     font-size: 18px;
     text-align: center;
     color: #333333;
-    width: 100%;
+    // width: 100%;
     height: 94px;
     padding: 30px;
     span {


### PR DESCRIPTION
## :: 최근 작업 주제

- [ ] 레이아웃 구현
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 장바구니 수정, 삭제 기능 구현

<br />

## :: 구현 사항 설명
<br>
1. 장바구니 수정 기능 추가

- 장바구니 페이지에서 수량 변경 시 localstroage 내부 cart에 담겨 있는 
상품의 개수와 가격이 수정되는 기능을 추가했습니다.

<br>
2. 장바구니 삭제 기능 추가

- 장바구니 페이지에서 삭제 버튼 클릭 시 localstroage 내부 cart에 담겨 있는 
상품의 아이디와 클릭한 상품의 아이디를 비교하여 삭제하는 기능을 추가했습니다..

<br />

## :: 성장 포인트

- 처음에는 장바구니 안에 있는 상품의 수량을 변경할 때 cart의 데이터를 가져오는 
useEffect 훅 내부의 의존성 배열에 있는 isUpdated의 값을 변경함으로써 
리렌더링될 수 있도록 구현했지만, 원하는 대로 동작하지 않았습니다.
새로고침 기능을 사용해 문제를 해결했습니다.

<br />

## :: 기타 질문 및 특이 사항

- 새로고침 기능 사용
