### PR TITLE
Refactor: 장바구니 페이지 scss 정리

### DIFF
--- a/src/components/CartProduct/CartProduct.js
+++ b/src/components/CartProduct/CartProduct.js
@@ -3,7 +3,7 @@ import css from './CartProduct.module.scss';
 import Image from '../../elements/Image';
 
 function CartProduct(props) {
-  const { firstProduct, cart } = props;
+  const { firstProduct, cart, setIsUpdated } = props;
   const [productInfo, setProductInfo] = useState([]);
   const id = cart.id;
 
@@ -43,7 +43,7 @@ function CartProduct(props) {
         })
       )
     );
-    window.location.reload();
+    setIsUpdated(true);
   };
 
   const countDown = async () => {
@@ -68,8 +68,8 @@ function CartProduct(props) {
           })
         )
       );
-      window.location.reload();
     }
+    setIsUpdated(true);
   };
 
   const deleteProduct = () => {
@@ -78,7 +78,7 @@ function CartProduct(props) {
       'cart',
       JSON.stringify(cart.filter(item => item.id !== id))
     );
-    window.location.reload();
+    setIsUpdated(true);
   };
 
   const imageList = productInfo?.productImages;

--- a/src/components/CartProduct/CartProduct.js
+++ b/src/components/CartProduct/CartProduct.js
@@ -105,7 +105,7 @@ function CartProduct(props) {
         </div>
       </td>
       <td className={css.price}>₩ {price}</td>
-      <td className={css.total_price}>₩ {count * price}</td>
+      <td className={css.price}>₩ {count * price}</td>
       {firstProduct && (
         <td className={css.ship}>
           <div>₩ 2,500</div>

--- a/src/components/CartProduct/CartProduct.module.scss
+++ b/src/components/CartProduct/CartProduct.module.scss
@@ -1,34 +1,52 @@
+@mixin price($b, $w) {
+  position: relative;
+  min-width: 160px;
+  bottom: $b;
+  width: $w;
+}
+
+@mixin count($border, $bg, $cursor: auto) {
+  border: $border;
+  background-color: $bg;
+  cursor: $cursor;
+}
+
+@mixin left($left) {
+  position: relative;
+  left: $left;
+}
+
+@mixin size($w: auto, $h: auto, $m: auto, $p: auto) {
+  width: $w;
+  height: $h;
+  margin: $m;
+  padding: $p;
+}
+
 .container {
-  height: 115px;
   border-top: 1px solid lightgray;
   margin: 0 auto;
   td {
     padding: 40px;
   }
   .info {
-    width: 440px;
-    margin: 0 auto;
-    text-align: center;
+    @include size($w: 440px, $m: 0 auto);
     display: flex;
     align-items: center;
     button {
-      width: 50px;
+      @include size($w: 50px, $m: 0, $p: 0);
       background-color: transparent;
       border: 0;
-      color: red;
       cursor: pointer;
-      padding: 0;
-      margin: 0;
     }
     .img {
-      position: relative;
-      left: 100px;
+      @include left(100px);
     }
     .product_name {
-      width: 300px;
+      @include left(10px);
+      width: 360px;
       font-size: 18px;
       text-align: left;
-      position: relative;
       .sub_category {
         font-size: 16px;
         margin: 4px 0;
@@ -37,50 +55,29 @@
     }
   }
   .count {
-    position: relative;
-    width: 185px;
-
     .buy_input {
       display: flex;
       border: 1px solid gray;
       padding: 4px;
-      position: relative;
-      bottom: 6px;
       input {
-        position: relative;
-        left: 6px;
+        @include count(0, transparent);
+        @include left(6px);
         width: 53px;
-        border: none;
         outline: none;
-        background-color: transparent;
         text-align: center;
       }
     }
     button {
-      border: 0;
-      cursor: pointer;
-      background-color: transparent;
+      @include count(0, transparent, pointer);
     }
   }
   .price {
-    position: relative;
-    bottom: 5px;
-    width: 160px;
-    min-width: 160px;
-  }
-  .total_price {
-    position: relative;
-    bottom: 5px;
-    width: 160px;
-    min-width: 160px;
+    @include price(5px, 160px);
   }
   .ship {
-    position: relative;
-    bottom: 10px;
+    @include price(10px, 300px);
     font-size: 14px;
     color: #acacac;
     line-height: 20px;
-    width: 300px;
-    min-width: 160px;
   }
 }

--- a/src/components/CartProduct/CartProduct.module.scss
+++ b/src/components/CartProduct/CartProduct.module.scss
@@ -4,18 +4,15 @@
   bottom: $b;
   width: $w;
 }
-
 @mixin count($border, $bg, $cursor: auto) {
   border: $border;
   background-color: $bg;
   cursor: $cursor;
 }
-
 @mixin left($left) {
   position: relative;
   left: $left;
 }
-
 @mixin size($w: auto, $h: auto, $m: auto, $p: auto) {
   width: $w;
   height: $h;

--- a/src/components/ProductInfo/ProductInfo.js
+++ b/src/components/ProductInfo/ProductInfo.js
@@ -23,8 +23,8 @@ function ProductInfo(props) {
   const reviewLength = productInfo?.productReviews?.length || 0;
   const weight = productInfo?.weight;
 
-  let { price } = productInfo;
-  let totalPrice = price * count;
+  const { price } = productInfo;
+  const totalPrice = price * count;
 
   const [mainCategory, setMainCategory] = useState('');
   const [mainList, setMainList] = useState([]);
@@ -65,7 +65,6 @@ function ProductInfo(props) {
           JSON.stringify([data, ...JSON.parse(localStorage.getItem('cart'))])
         );
       } else {
-        cart.id = 'test';
         localStorage.setItem(
           'cart',
           JSON.stringify(

--- a/src/elements/Image.js
+++ b/src/elements/Image.js
@@ -31,7 +31,6 @@ const Inner = styled.div`
   background-image: url('${props => props.src}');
   background-size: cover;
   background-position: center;
-  background-size: cover;
   object-fit: cover;
   width: ${props => (props.width ? props.width : props.size)}px;
   height: ${props => (props.height ? props.height : props.size)}px;

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -8,11 +8,12 @@ function Cart() {
 
   const cartList = JSON.parse(localStorage.getItem('cart'));
   const totalCount = cartList?.length;
-  let [totalPrice, setTotalPrice] = useState(0);
+  const [totalPrice, setTotalPrice] = useState(0);
   const [isUpdated, setIsUpdated] = useState(false);
 
   useEffect(() => {
     setIsUpdated(false);
+    setTotalPrice(0);
     for (let i = 0; i < cartList?.length; i++) {
       let price = cartList[i]?.totalPrice;
       setTotalPrice(prev => prev + price);
@@ -56,14 +57,26 @@ function Cart() {
             cartList.map((cart, idx) => {
               if (idx === 0)
                 return (
-                  <CartProduct key={idx} firstProduct={true} cart={cart} />
+                  <CartProduct
+                    key={idx}
+                    firstProduct={true}
+                    cart={cart}
+                    setIsUpdated={setIsUpdated}
+                  />
                 );
-              else return <CartProduct key={idx} cart={cart} />;
+              else
+                return (
+                  <CartProduct
+                    key={idx}
+                    cart={cart}
+                    setIsUpdated={setIsUpdated}
+                  />
+                );
             })}
         </tbody>
       </table>
       <div className={css.order_price}>
-        <span>총 {totalCount}개의 금액</span>{' '}
+        <span>총 {totalCount || 0}개의 금액</span>{' '}
         <span className={css.price}>₩ {isExist ? 0 : totalPrice}</span> +{' '}
         <span>배송비</span>{' '}
         <span className={css.price}>₩ {isExist ? 0 : 2500}</span> ={' '}

--- a/src/pages/Cart/Cart.module.scss
+++ b/src/pages/Cart/Cart.module.scss
@@ -1,97 +1,90 @@
+@mixin btn($bg, $border: 0, $color: black) {
+  background-color: $bg;
+  border: $border;
+  color: $color;
+}
+
+@mixin size($w, $h, $m: auto) {
+  width: $w;
+  height: $h;
+  margin: $m;
+}
+
+@mixin font($size, $weight: 900, $align: center) {
+  font-size: $size;
+  font-weight: $weight;
+  text-align: $align;
+}
+
 .container {
-  width: 1100px;
-  margin: 0 auto;
+  @include size(1100px, auto, 0 auto);
 
   h2 {
-    font-size: 42px;
-    height: 60px;
-    margin: 100px 0;
-    font-weight: 900;
-    text-align: center;
+    @include font(42px);
+    @include size(auto, 60px, 100px 0);
   }
 
   table {
-    width: 1100px;
-    margin: auto;
+    @include size(1100px, auto);
+    text-align: center;
+
     caption {
-      font-size: 22px;
+      @include font(22px, 900, left);
       height: 30px;
-      font-weight: 900;
-      position: relative;
-      text-align: left;
     }
+
+    tr {
+      height: 50px;
+    }
+
     th {
       color: #8f8f8f;
       border-top: 1px solid black;
       padding: 15px 0;
     }
-    td {
-      text-align: center;
-    }
-    .info {
-      width: 440px;
-      height: 50px;
-    }
-    .count {
-      width: 185px;
-      height: 50px;
-    }
-    .price {
-      width: 160px;
-      height: 50px;
-    }
-    .total_price {
-      width: 160px;
-      height: 50px;
-    }
-    .ship {
-      width: 120px;
-      height: 50px;
-    }
   }
+
   .order_price {
-    width: 1100px;
+    @include size(1100px, 94px);
+    @include font(18px, 400);
     background-color: rgb(224, 224, 224);
-    font-size: 18px;
-    text-align: center;
     color: #333333;
-    // width: 100%;
-    height: 94px;
     padding: 30px;
+
     span {
       padding: 10px;
     }
+
     .price {
       font-weight: 700;
     }
+
     .total_price {
-      font-size: 26px;
-      font-weight: 700;
+      @include font(26px, 700);
     }
   }
+
   .delete_btn {
+    @include btn(transparent, 0);
     cursor: pointer;
-    background-color: transparent;
-    border: 0;
     border-bottom: 1px solid;
     margin: 20px 0;
   }
+
   .buttons {
     display: flex;
     justify-content: center;
+
     :nth-child(1) {
-      background-color: white;
-      border: 1px solid black;
+      @include btn(white, 1px solid black);
     }
+
     :nth-child(2) {
-      background-color: black;
-      color: white;
-      border: 1px solid black;
+      @include btn(black, 1px solid black, white);
     }
+
     button {
-      width: 280px;
-      height: 63px;
-      margin: 30px;
+      @include size(280px, 63px, 30px);
       cursor: pointer;
     }
   }

--- a/src/pages/Cart/Cart.module.scss
+++ b/src/pages/Cart/Cart.module.scss
@@ -3,13 +3,11 @@
   border: $border;
   color: $color;
 }
-
 @mixin size($w, $h, $m: auto) {
   width: $w;
   height: $h;
   margin: $m;
 }
-
 @mixin font($size, $weight: 900, $align: center) {
   font-size: $size;
   font-weight: $weight;
@@ -18,71 +16,57 @@
 
 .container {
   @include size(1100px, auto, 0 auto);
-
   h2 {
     @include font(42px);
     @include size(auto, 60px, 100px 0);
   }
-
   table {
     @include size(1100px, auto);
     text-align: center;
-
     caption {
       @include font(22px, 900, left);
       height: 30px;
     }
-
     tr {
       height: 50px;
     }
-
     th {
       color: #8f8f8f;
       border-top: 1px solid black;
       padding: 15px 0;
     }
   }
-
   .order_price {
     @include size(1100px, 94px);
     @include font(18px, 400);
     background-color: rgb(224, 224, 224);
     color: #333333;
     padding: 30px;
-
     span {
       padding: 10px;
     }
-
     .price {
       font-weight: 700;
     }
-
     .total_price {
       @include font(26px, 700);
     }
   }
-
   .delete_btn {
     @include btn(transparent, 0);
     cursor: pointer;
     border-bottom: 1px solid;
     margin: 20px 0;
   }
-
   .buttons {
     display: flex;
     justify-content: center;
-
     :nth-child(1) {
       @include btn(white, 1px solid black);
     }
-
     :nth-child(2) {
       @include btn(black, 1px solid black, white);
     }
-
     button {
       @include size(280px, 63px, 30px);
       cursor: pointer;


### PR DESCRIPTION
## :: 최근 작업 주제

- [ ] 레이아웃 구현
- [ ] 기능 추가
- [ ] 리뷰 반영
- [X] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 장바구니 수정 및 삭제 시 새로고침 없이 리렌더링 되도록 수정
- 장바구니 페이지 scss 정리

<br />

## :: 구현 사항 설명
<br>
1. 장바구니 수정 및 삭제 시 새로고침 없이 리렌더링 되도록 수정

- 렌더링 시에 합계 가격이 초기화 될 수 있도록 useEffect 훅에
setTotalPrice(0)을 추가했습니다.

<br>
2. 장바구니 페이지 scss 정리

- 중복되는 부분들을 mixin과 include를 활용해 줄였습니다.

<br />

## :: 성장 포인트

- useEffect 훅에서 장바구니 총 가격을 구하고 있었는데, 상품 수량 변경이나 상품 삭제 시에
이전 총 가격을 초기화하지 않고 이전 총 가격에 추가로 더하고 있다는 사실을 깨달았습니다.
자신이 작성했던 코드에 대한 이해가 부족했던 것 같고, 꼼꼼하게 코드를 확인하지 못했던 
부분에 대해 반성하게 되는 계기가 되었습니다.


<br />

## :: 기타 질문 및 특이 사항

- 없음
