### PR TITLE
Add: 장바구니에 담긴 상품의 이미지 클릭 시 상품 상세 페이지로 이동 기능 추가

### DIFF
--- a/src/components/CartProduct/CartProduct.js
+++ b/src/components/CartProduct/CartProduct.js
@@ -90,7 +90,7 @@ function CartProduct(props) {
     <tr className={css.container}>
       <td className={css.info}>
         <button onClick={deleteProduct}>삭제</button>
-        {image && <Image className={css.img} size={70} src={image} />}
+        {image && <Image className={css.img} size={70} src={image} id={id} />}
         <div className={css.product_name}>
           <div>{name}</div>
           <div className={css.sub_category}>{subCategory}</div>

--- a/src/components/CartProduct/CartProduct.js
+++ b/src/components/CartProduct/CartProduct.js
@@ -21,10 +21,9 @@ function CartProduct(props) {
   const name = productInfo?.name;
   const subCategory = productInfo?.sub_category;
   const price = productInfo.price;
+  const count = cart.count;
 
-  const [count, setCount] = useState(cart.count);
   const countUp = () => {
-    setCount(count + 1);
     const cart = JSON.parse(localStorage.getItem('cart')) || [];
     localStorage.setItem(
       'cart',
@@ -49,7 +48,6 @@ function CartProduct(props) {
 
   const countDown = async () => {
     if (count > 1) {
-      setCount(count - 1);
       const cart = JSON.parse(localStorage.getItem('cart')) || [];
       localStorage.setItem(
         'cart',

--- a/src/elements/Image.js
+++ b/src/elements/Image.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 
-const Image = ({ src, size, width, height, setImage, ...props }) => {
+const Image = ({ src, size, width, height, setImage, id, ...props }) => {
+  const navigate = useNavigate();
   return (
     <Outter>
       <Inner
@@ -10,7 +12,10 @@ const Image = ({ src, size, width, height, setImage, ...props }) => {
         size={size}
         width={width}
         height={height}
-        onClick={() => (setImage ? setImage(src) : {})}
+        onClick={() => {
+          if (setImage) setImage(src);
+          else if (id) navigate(`/productdetail/${id}`);
+        }}
       />
     </Outter>
   );


### PR DESCRIPTION
## :: 최근 작업 주제 

- [ ] 레이아웃 구현
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [X] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 장바구니 삭제 시 수량이 비정상적으로 변하는 현상 해결
- 장바구니에 담긴 상품의 이미지 클릭 시 상품 상세 페이지로 이동 기능 구현

<br />

## :: 구현 사항 설명
<br>
1. 장바구니 삭제 시 수량이 비정상적으로 변하는 현상 해결

- 장바구니에서 개별 삭제 시 수량이 삭제된 상품의 수량으로 나타나는
현상이 있었고, useState를 사용한 부분을 제거함으로써 문제를
해결했습니다.

<br>
2. 장바구니에 담긴 상품의 이미지 클릭 시 상품 상세 페이지로 이동 기능 추가

- styled-components를 사용해 만든 이미지 컴포넌트와 props를 활용해
이미지 클릭 시 상품 상세 페이지로 이동 기능을 구현했습니다.

<br />

## :: 성장 포인트

- useState 훅에 대한 이해를 높일 수 있었습니다.
- props에 대한 이해를 높일 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항

- 없음
