### PR TITLE
ADD : 검색창에서 제품 검색 후 제품 위에 마우스 올리면 확대되는 기능 추가

### DIFF
--- a/src/components/Home/Second/Second.js
+++ b/src/components/Home/Second/Second.js
@@ -36,16 +36,18 @@ function Second() {
   const onMouseDown = e => {
     setStart(e.clientX);
     setIsPressed(true);
+    slider.current.style.transition = 'transform 0.1s';
     e.target.draggable = false;
   };
 
   const onMouseUp = e => {
+    slider.current.style.transition = 'transform 1s';
     setCurrentSpot(prev => {
       if (prev < 0) {
         return 0;
       }
-      if (prev > 2000) {
-        return 2000;
+      if (prev > 2015) {
+        return 2015;
       } else {
         return prev + e.clientX - start;
       }
@@ -55,6 +57,7 @@ function Second() {
   };
 
   const onMouseLeave = e => {
+    slider.current.style.transition = 'transform 1s';
     setIsPressed(false);
     setCurrentSpot(prev => {
       if (prev < 0) {
@@ -70,14 +73,13 @@ function Second() {
 
   const onMouseMove = e => {
     if (isPressed) {
-      slider.current.style.transition = 'transform 0.1s';
       slider.current.style.transform = `translate(-${
         (currentSpot + e.clientX - start - 45 < 0
           ? 0
           : currentSpot + e.clientX - start - 45,
-        currentSpot + e.clientX - start - 45 > 2000)
-          ? 2000
-          : currentSpot + e.clientX - start - 45
+        currentSpot + e.clientX - start - 45 > 2015
+          ? 2015
+          : currentSpot + e.clientX - start - 45)
       }px)`;
     }
   };

--- a/src/pages/Search/Searchdetail.js
+++ b/src/pages/Search/Searchdetail.js
@@ -1,33 +1,32 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import css from './Searchdetail.module.scss';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Searchdetail = ({ data }) => {
   const navigate = useNavigate();
+  const [on, setOn] = useState('');
   const backImg = useRef();
 
   const Backimg = styled.div`
     position: absolute;
-    top: 0;
-    left: 0;
+    width: 20%;
+    height: 20%;
     background-image: url(${data.productImages[0].url});
-    width: 100%;
-    height: 100%;
     background-repeat: no-repeat;
-    background-position: center;
-    background-size: cover;
-    transition: transform 0.5s ease-out;
-    object-fit: cover;
+    background-size: 1000% 1000%;
+    border: 1px solid black;
+    pointer-events: none;
+    border-radius: 100%;
   `;
   const Img = styled.div`
     position: relative;
     width: 100%;
-    height: 350px;
+    height: 100%;
     cursor: pointer;
     background-image: url(${data.productImages[0].url});
-    background-size: cover;
-    overflow: hidden;
+    background-size: 100% 100%;
+    background-position: center;
   `;
 
   const gotoproduct = () => {
@@ -35,15 +34,21 @@ const Searchdetail = ({ data }) => {
   };
 
   const enter = () => {
-    backImg.current.style.transform = 'scale(2)';
+    setOn(true);
   };
   const leave = () => {
-    backImg.current.style.transform = 'scale(1)';
+    setOn(false);
   };
   const move = e => {
-    console.log(e.nativeEvent.offsetX);
-    console.log(e.nativeEvent.offsetY);
-    backImg.current.style.transformOrigin = `${e.nativeEvent.offsetX}px ${e.nativeEvent.offsetY}px`;
+    backImg.current.style.left = `${
+      e.nativeEvent.offsetX - e.target.getBoundingClientRect().width / 10
+    }px`;
+    backImg.current.style.top = `${
+      e.nativeEvent.offsetY - e.target.getBoundingClientRect().width / 10
+    }px`;
+    backImg.current.style.backgroundPosition = `-${
+      (e.nativeEvent.offsetX - 25) * 2
+    }px -${(e.nativeEvent.offsetY - 25) * 2}px`;
   };
   return (
     <div className={css.product}>
@@ -53,7 +58,7 @@ const Searchdetail = ({ data }) => {
         onMouseLeave={leave}
         onMouseMove={move}
       >
-        <Backimg ref={backImg} />
+        {on ? <Backimg ref={backImg} /> : null}
       </Img>
       <p className={css.info}>{data.name}</p>
       <p className={css.info}> {data.hashtags}</p>

--- a/src/pages/Search/Searchdetail.js
+++ b/src/pages/Search/Searchdetail.js
@@ -44,11 +44,13 @@ const Searchdetail = ({ data }) => {
       e.nativeEvent.offsetX - e.target.getBoundingClientRect().width / 10
     }px`;
     backImg.current.style.top = `${
-      e.nativeEvent.offsetY - e.target.getBoundingClientRect().width / 10
+      e.nativeEvent.offsetY - e.target.getBoundingClientRect().height / 10
     }px`;
     backImg.current.style.backgroundPosition = `-${
-      (e.nativeEvent.offsetX - 25) * 2
-    }px -${(e.nativeEvent.offsetY - 25) * 2}px`;
+      (e.nativeEvent.offsetX - e.target.getBoundingClientRect().width / 20) * 2
+    }px -${
+      (e.nativeEvent.offsetY - e.target.getBoundingClientRect().height / 20) * 2
+    }px`;
   };
   return (
     <div className={css.product}>

--- a/src/pages/Search/Searchdetail.js
+++ b/src/pages/Search/Searchdetail.js
@@ -1,22 +1,60 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import css from './Searchdetail.module.scss';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 
 const Searchdetail = ({ data }) => {
   const navigate = useNavigate();
+  const backImg = useRef();
+
+  const Backimg = styled.div`
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-image: url(${data.productImages[0].url});
+    width: 100%;
+    height: 100%;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
+    transition: transform 0.5s ease-out;
+    object-fit: cover;
+  `;
+  const Img = styled.div`
+    position: relative;
+    width: 100%;
+    height: 350px;
+    cursor: pointer;
+    background-image: url(${data.productImages[0].url});
+    background-size: cover;
+    overflow: hidden;
+  `;
 
   const gotoproduct = () => {
     navigate(`/productdetail/${data.id}`);
   };
 
+  const enter = () => {
+    backImg.current.style.transform = 'scale(2)';
+  };
+  const leave = () => {
+    backImg.current.style.transform = 'scale(1)';
+  };
+  const move = e => {
+    console.log(e.nativeEvent.offsetX);
+    console.log(e.nativeEvent.offsetY);
+    backImg.current.style.transformOrigin = `${e.nativeEvent.offsetX}px ${e.nativeEvent.offsetY}px`;
+  };
   return (
     <div className={css.product}>
-      <img
-        className={css.img}
-        src={data.productImages[0].url}
+      <Img
         onClick={gotoproduct}
-        alt="제품이미지"
-      />
+        onMouseEnter={enter}
+        onMouseLeave={leave}
+        onMouseMove={move}
+      >
+        <Backimg ref={backImg} />
+      </Img>
       <p className={css.info}>{data.name}</p>
       <p className={css.info}> {data.hashtags}</p>
       <p className={css.info}>{data.price}</p>

--- a/src/pages/Search/Searchdetail.module.scss
+++ b/src/pages/Search/Searchdetail.module.scss
@@ -1,15 +1,10 @@
 .product {
   width: 25%;
+  height: 350px;
   display: inline-block;
   padding: 5px;
 }
-.img {
-  position: relative;
-  width: 100%;
-  height: 350px;
-  object-fit: cover;
-  cursor: pointer;
-}
+
 .info {
   text-align: center;
 }

--- a/src/pages/Search/Searchdetail.module.scss
+++ b/src/pages/Search/Searchdetail.module.scss
@@ -4,6 +4,7 @@
   padding: 5px;
 }
 .img {
+  position: relative;
   width: 100%;
   height: 350px;
   object-fit: cover;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 

제품 이미지에 마우스 오버시 해당 부분 확대된 돋보기로 보여지는 기능

<br />

## :: 구현 사항 설명

1. 원본 비율의 이미지와 확대된 이미지 태그를 만들다.
2. 확대된 이미지는 마우스 오버시 state를 변경하여 랜던딩되게 조건을 만든다.
3. 위의 두 태그를 자식으로 두는  div 태그에 overflow hidden을 주어 레이아웃을 잡는다.
4.  확대된 이미지를 돋보기 모양으로 스타일링 후 원본 이미지의 마우스 좌표를 따서 연동한다.
5. 좌표를 연동하고 반응형으로 구현 가능하게 %로 값을준다.


<br />

## :: 성장 포인트 

두장의 이미지를 겹쳐서 활용하는법에 대해서 알 수 있었습니다.
마우스 좌표관련 및 css의 다양한 도구들을 알 수 있었습니다.

<br />

특이사항 

여러분 이제 그만 올릴게요 죄송해요 ~~ 다들 1차 프로젝트 하시느라고 고생 많으셨어요 ~~ 2차도 화이팅!!
이거 별것도 아닌데 이거 하느라고 꿀같은 내 주말을 다 보내버렸네요 넘나 슬프다~